### PR TITLE
removed comma, validate JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Stuff for Vivaldi Browser, Bringing together various gists into a repo
 {
     "application_path": "C:\\Program Files\\Vivaldi\\Application",
     "active_mods": [
-        "addressbar_button_order",
+        "addressbar_button_order"
     ],
     "active_page_actions": [],
     "splash_fg": "#67d0ea",


### PR DESCRIPTION
In the example there is a comma, but only one element. This causes a JSON error and the script won't run. When you remove the comma is passes at https://jsonlint.com/ and the python script works. I recommend adding a working example config file in the repo