### PR TITLE
lost focus if press button

### DIFF
--- a/mods/advancedPanels.js
+++ b/mods/advancedPanels.js
@@ -524,6 +524,7 @@ const l10n = {
                  */
                 function onActivate(){
                     updateList();
+                    document.activeElement.blur();
                 }
 
                 /**


### PR DESCRIPTION
It's lost focus session panel if open session panel.

If open session pannel, focus on `vivaldi-webpanel`. 
Then don't close panel by shortcut key.
